### PR TITLE
Bump Holo Nixpkgs pin to b6137d8abb302666128943e37a7ee893bf0f4b0b

### DIFF
--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/4d9bbf9971faac5e7fe73cb2189e4f0ee94778c8.tar.gz";
-  sha256 = "1fbzq4dfm03bhnz76smmklkydqb0z8wxsy7rlsm8y6pd6c53dzsq";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/b6137d8abb302666128943e37a7ee893bf0f4b0b.tar.gz";
+  sha256 = "1si369a25fa9kxx0v50yv7p4g6dm1c6dm21fpyzd1fhplhl9m9pz";
 })


### PR DESCRIPTION
Currently pinned Holo Nixpkgs version doesn't contain `mkJobsets`, which prevents #10 from working.