### PR TITLE
Updates required for Chaperone rc0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,13 +29,13 @@
       }
     },
     "@holo-host/chaperone": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@holo-host/chaperone/-/chaperone-0.1.16.tgz",
-      "integrity": "sha512-2TDr9kKTdigYRguzXX28Kc40PkbCaG2xDvC/XVdnLLqmgA3aE48+0fIa0QBLQ+AmAtg8Ht9cPAyIAd/rW34BOg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@holo-host/chaperone/-/chaperone-0.2.0.tgz",
+      "integrity": "sha512-SFVI3aSgk0n+IY5/AvmXU5o94Q7+2E9llcjfNcc1V4wDCGTb+WvtIkzQ9BGyeRF8NkHMS3Gd3yxoYaBt0CBr5w==",
       "dev": true,
       "requires": {
         "@holo-host/comb": "^0.1.5",
-        "@holo-host/cryptolib": "^0.1.1",
+        "@holo-host/cryptolib": "^0.2.1",
         "@whi/http_utils": "^0.1.0",
         "@whi/printf": "^1.0.0",
         "@whi/stdlog": "^0.3.1",
@@ -46,12 +46,13 @@
       },
       "dependencies": {
         "@holo-host/cryptolib": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@holo-host/cryptolib/-/cryptolib-0.1.1.tgz",
-          "integrity": "sha512-ry2oU786+rTxiKPtbC+kBgNlGhVd1QrpxvQgq4iQ4/NT2l4vvSLSvww2QZyjKcu9l2Qjl2r2cZND6MF58TjnqA==",
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@holo-host/cryptolib/-/cryptolib-0.2.1.tgz",
+          "integrity": "sha512-sXGnN42HlK6YG3UJDhUIFLb9eFU/nqeQGCs1UlI02odPGZl8TJzlsilv0IJrRCdDbguiHLsPKsp446Rfk0w1hg==",
           "dev": true,
           "requires": {
             "@holo-host/wasm-key-manager": "0.0.5",
+            "base-x": "^3.0.7",
             "multihashes": "0.4.15"
           }
         },
@@ -489,9 +490,9 @@
       }
     },
     "commander": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
-      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
     "compound-subject": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sprintf-js": "^1.1.2"
   },
   "devDependencies": {
-    "@holo-host/chaperone": "^0.1.16",
+    "@holo-host/chaperone": "^0.2.0",
     "@types/node": "^12.11.1",
     "braintree-jsdoc-template": "^3.3.0",
     "chai": "^4.2.0",

--- a/tests/e2e/test_chaperone.js
+++ b/tests/e2e/test_chaperone.js
@@ -91,18 +91,21 @@ describe("Server", () => {
 	    response			= await page.evaluate(async function ( host_agent_id, instance_prefix )  {
 		const client = new Chaperone({
 		    "mode": Chaperone.DEVELOP,
+
+		    "connection": {
+			"ssl": false,
+			"host": "localhost",
+			"port": 4656,
+		    },
 		    
-		    "host": "localhost",
 		    host_agent_id,
-		    "port": 4656,
-		    "ssl": false,
-		    
 		    "instance_prefix": instance_prefix, // NOT RANDOM: this matches the hash
 							// hard-coded in Chaperone
 
 		    "timeout": 2000,
 		    "debug": true,
 		});
+		client.skip_assign_host	= true;
 
 		function delay(t, val) {
 		    return new Promise(function(resolve) {

--- a/tests/setup_chaperone.js
+++ b/tests/setup_chaperone.js
@@ -39,8 +39,6 @@ const made_up_happ_hash_for_test	= "QmV1NgkXFwromLvyAmASN7MbgLtgUaEYkozHPGUxcHAb
 // Mock Resolver responses
 mock_fetch.mock(/.*resolver-dev\.holo.host\/resolve\/hosts\/?/, () => {
     const response			= {
-	"requestURL": "example.com",
-	"happ_id": made_up_happ_hash_for_test,
 	"hosts":[
 	    "localhost"
 	],
@@ -50,6 +48,7 @@ mock_fetch.mock(/.*resolver-dev\.holo.host\/resolve\/hosts\/?/, () => {
 });
 mock_fetch.mock(/.*resolver-dev\.holo.host\/resolve\/happId\/?/, () => {
     const response			= {
+	"url": "example.com",
 	"happ_id": made_up_happ_hash_for_test,
     };
     log.debug("Mock Resolver response for /resolve/happId: %s", response );

--- a/tests/setup_chaperone.js
+++ b/tests/setup_chaperone.js
@@ -37,15 +37,28 @@ global.document				= {
 const made_up_happ_hash_for_test	= "QmV1NgkXFwromLvyAmASN7MbgLtgUaEYkozHPGUxcHAbSL";
 
 // Mock Resolver responses
-mock_fetch.mock(/.*resolver\.holohost.net\/?/, {
-    "requestURL": "example.com",
-    "hash": made_up_happ_hash_for_test,
-    "hosts":[
-	"localhost"
-    ],
+mock_fetch.mock(/.*resolver-dev\.holo.host\/resolve\/hosts\/?/, () => {
+    const response			= {
+	"requestURL": "example.com",
+	"happ_id": made_up_happ_hash_for_test,
+	"hosts":[
+	    "localhost"
+	],
+    };
+    log.debug("Mock Resolver response for /resolve/hosts: %s", response );
+    return response;
 });
-mock_fetch.mock(/.*resolver\.holohost.net\/resolve\/hostname\/?/, {
-    "hash": made_up_happ_hash_for_test,
+mock_fetch.mock(/.*resolver-dev\.holo.host\/resolve\/happId\/?/, () => {
+    const response			= {
+	"happ_id": made_up_happ_hash_for_test,
+    };
+    log.debug("Mock Resolver response for /resolve/happId: %s", response );
+    return response;
+});
+mock_fetch.mock(/.*resolver-dev\.holo.host\/update\/assignHost\/?/, () => {
+    const status			= 200;
+    log.debug("Mock Resolver response for /update/assignHost: %s", status );
+    return status;
 });
 
 


### PR DESCRIPTION
To run tests, you'll have to use a local install of Chaperone (`develop`)

`make use-local-chaperone`
