### PR TITLE
Add integration test for wormhole unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ class Envoy {
 	await this.http_server.close();
     }
 
-    signingRequest ( agent_id : string, payload : string ) {
+    signingRequest ( agent_id : string, payload : string, timeout = 5_000 ) {
 	return new Promise((f,r) => {
 	    const payload_id		= this.payload_counter++;
 	    const event			= `${agent_id}/wormhole/request`;
@@ -606,6 +606,8 @@ class Envoy {
 	    }
 	    
 	    this.pending_signatures[ payload_id ] = [ payload, f, r ];
+
+	    setTimeout(() => r("Failed to get signature from Chaperone"), timeout );
 
 	    log.debug("Send signing request #%s to Agent %s", payload_id, agent_id );
 	    this.ws_server.emit( event, [ payload_id, payload ] );

--- a/tests/integration/test_server.js
+++ b/tests/integration/test_server.js
@@ -41,6 +41,7 @@ describe("Server", () => {
 	log.info("Stopping Conductor...");
 	await conductor.stop( 60_000 );
     });
+
     
     // it("should process request and respond", async () => {
     // 	try {
@@ -115,6 +116,21 @@ describe("Server", () => {
 	    expect( client.anonymous	).to.be.false;
 	    expect( client.agent_id	).to.equal("HcSCj43itVtGRr59tnbrryyX9URi6zpkzNKtYR96uJ5exqxdsmeO8iWKV59bomi");
 	} finally {
+	}
+    });
+
+    it("should fail because wormhole is closed", async function () {
+	const fail_client		= await setup.client();
+	try {
+	    await fail_client.signIn( "someone@example.com", "Passw0rd!" );
+
+	    const agent_id		= fail_client.agent_id;
+	    expect( agent_id		).to.equal("HcSCj43itVtGRr59tnbrryyX9URi6zpkzNKtYR96uJ5exqxdsmeO8iWKV59bomi");
+
+	    const zome_call		= fail_client.callZomeFunction( "holofuel", "transactions", "ledger_state" );
+	    fail_client.disconnect();
+	} finally {
+	    fail_client.close();
 	}
     });
 

--- a/tests/integration/test_server.js
+++ b/tests/integration/test_server.js
@@ -129,7 +129,7 @@ describe("Server", () => {
 	}
     });
 
-    it("should fail because wormhole is closed", async function () {
+    it("should fail capability signing of zome-call because wormhole is closed", async function () {
 	this.timeout( 30_000 );
 
 	let failed			= false;

--- a/tests/integration/test_server.js
+++ b/tests/integration/test_server.js
@@ -149,7 +149,7 @@ describe("Server", () => {
 	} catch ( err ) {
 	    failed			= true;
 
-	    expect( err.message		).to.have.string("Capability");
+	    expect( err.message		).to.have.string("Caller does not have Capability to make that call");
 	} finally {
 	    fail_client.close();
 	}

--- a/tests/setup_conductor.js
+++ b/tests/setup_conductor.js
@@ -43,7 +43,7 @@ async function start_conductor () {
 		if ( line.trim() === "" ) // for some reason there are many empty lines
 		    continue;
 		
-		console.log("HOLOCHAIN STDOUT:", line );
+		console.log("HOLOCHAIN STDOUT:", line, "\033[0m" );
 	    }
 	});
 
@@ -58,7 +58,7 @@ async function start_conductor () {
 		
 		let lc_line		= line.toLowerCase();
 		if ( hc_log_filters.some(key => lc_line.includes(key)) ) {
-		    console.log("HOLOCHAIN ERROR :", line );
+		    console.log("HOLOCHAIN ERROR :", line, "\033[0m" );
 		}
 	    }
 	});


### PR DESCRIPTION
The integration test sequence causes the signing error between sign-up and sign-in of the main client.  If the subsequent tests pass, this proves that the Conductor is fixed.  The previous conductor would have panicked and been permanently stalled.