### PR TITLE
Fix Envoy becoming permanently disconnected from Conductor [B-03360]

### DIFF
--- a/rpc-websocket-wrappers/client.js
+++ b/rpc-websocket-wrappers/client.js
@@ -42,6 +42,11 @@ class WebSocket extends RPCWebSocket {
     closed ( timeout = 1000 ) {
 	return async_with_timeout(() => {
 	    return new Promise((f,r) => {
+		if ( this.socket.readyState === 3 ) {
+		    log.silly("RPC WebSocket client (%s) is already in CLOSED state (%s)", this.name, this.socket.readyState );
+		    return f();
+		}
+
 		return this.on("close", () => {
 		    log.silly("'close' event triggered on RPC WebSocket client (%s)", this.name );
 		    f();

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,9 @@ class HoloError extends Error {
 
 
 function createRPCWebSocketClient ( name, port, rpc_options = RPC_CLIENT_OPTS ) {
-    const client			= new WebSocket(`ws://localhost:${port}`, rpc_options );
+    const url				= `ws://localhost:${port}`;
+    log.silly("Connecting RPC WebSocket client to (%s) with options: %s", url, rpc_options );
+    const client			= new WebSocket(url, rpc_options );
     client.name				= name;
     client.port				= port;
 

--- a/tests/e2e/test_chaperone.js
+++ b/tests/e2e/test_chaperone.js
@@ -49,7 +49,7 @@ describe("Server", () => {
     let http_ctrls, http_url;
 
     before(async function() {
-	this.timeout(10_000);
+	this.timeout(300_000);
 
 	log.info("Starting conductor");
 	await conductor.start();

--- a/tests/integration/test_server.js
+++ b/tests/integration/test_server.js
@@ -16,7 +16,7 @@ describe("Server", () => {
     let client;
 
     before(async function() {
-	this.timeout(30_000);
+	this.timeout(300_000);
 
 	log.info("Starting conductor");
 	await conductor.start();

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -210,11 +210,25 @@ describe("Server with mock Conductor", () => {
 	}
     });
 
-    it("should disconnect Envoy's websocket clients", async () => {
+    it("should automatically re-connect a broken client in order to call Conductor", async function () {
+	conductor.general.once("call", async function ( data ) {
+	    return ZomeAPIResult(true);
+	});
+
+	log.warn("Closing 'service' RPC WebSocket Client");
+	envoy.hcc_clients["service"].close();
+
+	const response			= await client.callZomeFunction( "holofuel", "transactions", "list_pending" );
+	log.debug("Response: %s", response );
+
+	expect( response.Ok		).to.be.true;
+    });
+
+    it("should disconnect Envoy's websocket clients", async function () {
 	try {
 	    await conductor.stop();
 
-	    log.silly("Issuing zome call while conductor stoped");
+	    log.silly("Issuing zome call while conductor stopped");
 	    const request		= client.callZomeFunction( "holofuel", "transactions", "list_pending" );
 
 	    log.silly("Restart conductor");


### PR DESCRIPTION
This replaces the need for RPC WebSocket auto-reconnect by having Envoy check the ready state and create a new client if the current one is closed.

Solution for issue https://github.com/Holo-Host/holo-envoy/issues/14