### PR TITLE
Add more unit tests for ws wrappers and fix a potential bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "puppeteer": "^2.1.1",
     "superstruct": "^0.8.3",
     "typescript": "^3.6.4",
-    "why-is-node-running": "^2.1.2"
+    "why-is-node-running": "^2.1.2",
+    "ws": "^7.4.3"
   }
 }

--- a/src/websocket-wrappers/holochain.ts
+++ b/src/websocket-wrappers/holochain.ts
@@ -27,8 +27,19 @@ class HcAdminWebSocket extends AdminWebsocket {
     return this.closed();
   }
 
-  opened = () => new Promise<void>((resolve, reject) => this.client.socket.addEventListener("open", () => resolve()));
-  closed = () => new Promise<void>((resolve, reject) => this.client.socket.addEventListener("close", () => resolve()));
+  opened = () => new Promise<void>((resolve, reject) => {
+    this.client.socket.addEventListener("open", () => resolve());
+    if (this.client.socket.readyState === Websocket.OPEN) {
+      resolve();
+    }
+  });
+
+  closed = () => new Promise<void>((resolve, reject) => {
+    this.client.socket.addEventListener("close", () => resolve());
+    if (this.client.socket.readyState === Websocket.CLOSED || this.client.socket.readyState === Websocket.CONNECTING) {
+      resolve();
+    }
+  });
 }
 
 class HcAppWebSocket extends AppWebsocket {
@@ -44,9 +55,19 @@ class HcAppWebSocket extends AppWebsocket {
     return this.closed();
   }
 
-  opened = () => new Promise<void>((resolve, reject) => this.client.socket.addEventListener("open", () => resolve()));
-  closed = () => new Promise<void>((resolve, reject) => this.client.socket.addEventListener("close", () => resolve()));
-}
+  opened = () => new Promise<void>((resolve, reject) => {
+    this.client.socket.addEventListener("open", () => resolve());
+    if (this.client.socket.readyState === Websocket.OPEN) {
+      resolve();
+    }
+  });
+
+  closed = () => new Promise<void>((resolve, reject) => {
+    this.client.socket.addEventListener("close", () => resolve());
+    if (this.client.socket.readyState === Websocket.CLOSED || this.client.socket.readyState === Websocket.CONNECTING) {
+      resolve();
+    }
+  });}
 
 export {
   HcAdminWebSocket, HcAppWebSocket

--- a/tests/unit/test_ws_wrapper.js
+++ b/tests/unit/test_ws_wrapper.js
@@ -1,0 +1,43 @@
+const expect = require('chai').expect;
+const Websocket = require('ws');
+const { HcAppWebSocket, HcAdminWebSocket } = require('../../build/websocket-wrappers/holochain');
+
+let TEST_WS_SERVER
+before(async () => {
+    TEST_WS_SERVER = new Websocket.Server({ host: "localhost", port: 62831 });
+    await new Promise((resolve, reject) => TEST_WS_SERVER.once("listening", resolve));
+})
+
+after(() => {
+    TEST_WS_SERVER.close();
+})
+
+testWs(HcAppWebSocket, "app websocket");
+testWs(HcAdminWebSocket, "admin websocket");
+
+function testWs(WsClass, name) {
+    describe(name, () => {
+        it("resolves opened immediately if already open", async () => {
+            const ws = new WsClass("ws://localhost:62831");
+            await ws.opened();
+            expect(ws.client.socket.readyState).to.equal(Websocket.OPEN);
+            await ws.opened();
+            ws.close();
+        })
+        
+        it("resolves closed immediately if already closed", async () => {
+            const ws = new WsClass("ws://localhost:62831");
+            await ws.opened();
+            await ws.close();
+            expect(ws.client.socket.readyState).to.equal(Websocket.CLOSED);
+            await ws.closed();
+        })
+
+        it("can be closed before being opened", async () => {
+            const ws = new WsClass("ws://localhost:62831");
+            expect(ws.client.socket.readyState).to.equal(Websocket.CONNECTING);
+            await ws.close();
+            expect(ws.client.socket.readyState).to.equal(Websocket.CONNECTING);
+        })
+    })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,7 +2224,7 @@ ws@^6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.3.0, ws@^7.3.1, ws@^7.4.0:
+ws@^7.3.0, ws@^7.3.1, ws@^7.4.0, ws@^7.4.3:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
   integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==


### PR DESCRIPTION
Changes:
- Changes the holochain websocket wrappers to return from `await wsWrapper.closed()` or `await wsWrapper.opened()` immediately if the socket is already in that state.
  - This bug hasn't shown up yet in practice and if it did show up it would be envoy occasionally hanging on startup because it doesn't realize that the websockets are connected. 
- Adds unit tests for that functionality and a couple of other behaviors of the websocket wrappers
