### PR TITLE
Fix anonymous zome call provenance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -465,7 +465,7 @@ class Envoy {
           "fn_name": call_spec["function"],
           "payload": decodedArgs,
           "cap": null, // Note: when null, this call will pass when the agent has an 'Unrestricted' status (this includes all calls to an agent's own chain)
-          "provenance": Codec.AgentId.decodeToHoloHash(agent_id),
+          "provenance": Buffer.from(hosted_app_cell_id[1]),
         });
       } catch (err) {
         log.error("Failed during Conductor call: %s", String(err));


### PR DESCRIPTION
For an anonymous zome call, the provenance must be the host public key since the provenance must match the key associated with the cell. Before this change, the provenance uses the random public key that is generated in chaperone and therefore means that any anonymous zome call results in `CONDUCTOR CALL ERROR: No capabilities grant has been committed that allows the CapSecret None to call the function...`