### PR TITLE
Improve conductor call error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@holo-host/chaperone": "git://github.com/Holo-Host/chaperone.git#620c84181efff68ea30eec8e2c3fdd94692c3921",
-    "@holo-host/mock-conductor": "^0.2.1",
+    "@holo-host/mock-conductor": "^0.3.1",
     "@holochain-open-dev/holochain-run-dna": "^0.3.2",
     "@types/node": "^12.11.1",
     "braintree-jsdoc-template": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@holo-host/chaperone": "git://github.com/Holo-Host/chaperone.git#620c84181efff68ea30eec8e2c3fdd94692c3921",
-    "@holo-host/mock-conductor": "git://github.com/Holo-Host/mock-conductor.git#29cd64a2dbdb20d1377983ea7546f3e1e667361d",
+    "@holo-host/mock-conductor": "^0.2.1",
     "@holochain-open-dev/holochain-run-dna": "^0.3.2",
     "@types/node": "^12.11.1",
     "braintree-jsdoc-template": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@holo-host/chaperone": "git://github.com/Holo-Host/chaperone.git#620c84181efff68ea30eec8e2c3fdd94692c3921",
-    "@holo-host/mock-conductor": "^0.3.0",
+    "@holo-host/mock-conductor": "git://github.com/Holo-Host/mock-conductor.git#29cd64a2dbdb20d1377983ea7546f3e1e667361d",
     "@holochain-open-dev/holochain-run-dna": "^0.3.2",
     "@types/node": "^12.11.1",
     "braintree-jsdoc-template": "^3.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,17 +322,18 @@ class Envoy {
           if (this.opts.hosted_app && this.opts.hosted_app!.dnas && this.opts.mode === Envoy.DEVELOP_MODE) {
             dnas = this.opts.hosted_app.dnas;
 					} else {
-            const installedDnas = appInfo.cell_data.map(([cell_id, dna_alias]) => ({ nick: dna_alias, hash: cell_id[0]}));
+            dnas = appInfo.cell_data.map(([cell_id, dna_alias]) => ({ nick: dna_alias, hash: cell_id[0], membrane_proof }));
 
-            if (membrane_proof) {
-              log.normal("App includes membrane_proof: %s", membrane_proof);
-              dnas = { ...installedDnas, membrane_proof }
-            } else {
-              dnas = installedDnas;
-            }
-
-            log.debug('installedDnas : %s', installedDnas);
 					}
+
+          if (membrane_proof) {
+            log.normal("App includes membrane_proof: %s", membrane_proof);
+            for (const dnaIdx in dnas) {
+              dnas[dnaIdx].membrane_proof = membrane_proof
+            }
+          }
+
+          log.debug('dnas : %j', dnas);
 
           adminResponse = await this.callConductor("admin", 'installApp', {
             installed_app_id: hosted_agent_instance_app_id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -827,7 +827,7 @@ class Envoy {
       } catch (error) {
         console.log("CONDUCTOR CALL ERROR: ");
         console.log(error);
-        throw new Error(`CONDUCTOR CALL ERROR: ${error}`);
+        throw new Error(`CONDUCTOR CALL ERROR: ${JSON.stringify(error.data)}`);
       }
 
       if (callAgent === "app") {

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -507,63 +507,63 @@ describe("Server with mock Conductor", () => {
     expect(deactivateAppCalled).to.be.true;
   });
 
-it('should return a useful error message when a conductor call fails', async () => {
-  client = await setup.client({})
+  it('should return a useful error message when a conductor call fails', async () => {
+    client = await setup.client({})
 
-  const callZomeData = {
-    cell_id: MOCK_CELL_ID,
-    zome_name: 'zome',
-    fn_name: 'zome_fn'
-  }
-  const expected_response = {
-    type: 'error',
-    data: {
-      type: 'fake conductor error type',
-      data: 'fake conductor error data'
+    const callZomeData = {
+      cell_id: MOCK_CELL_ID,
+      zome_name: 'zome',
+      fn_name: 'zome_fn'
     }
-  }
-  appConductor.once(
-    MockConductor.ZOME_CALL_TYPE,
-    callZomeData,
-    expected_response.data,
-    { returnError: true }
-  )
-
-  const servicelogData = {
-    cell_id: MOCK_CELL_ID,
-    zome_name: 'service',
-    fn_name: 'log_activity'
-  }
-  const activity_log_response = 'Activity Log Success Hash'
-  appConductor.once(
-    MockConductor.ZOME_CALL_TYPE,
-    servicelogData,
-    activity_log_response
-  )
-
-  const response = await client.callZomeFunction(
-    'dna_alias',
-    'zome',
-    'zome_fn',
-    {
-      zomeFnArgs: 'String Input'
+    const expected_response = {
+      type: 'error',
+      data: {
+        type: 'fake conductor error type',
+        data: 'fake conductor error data'
+      }
     }
-  )
+    appConductor.once(
+      MockConductor.ZOME_CALL_TYPE,
+      callZomeData,
+      expected_response.data,
+      { returnError: true }
+    )
 
-  log.debug('Response: %s', response)
-
-  delete response._metadata
-  expect(response).to.deep.equal({
-    type: 'error',
-    payload: {
-      source: 'HoloError',
-      error: 'HoloError',
-      message:
-        'Error: CONDUCTOR CALL ERROR: {"type":"fake conductor error type","data":"fake conductor error data"}',
-      stack: []
+    const servicelogData = {
+      cell_id: MOCK_CELL_ID,
+      zome_name: 'service',
+      fn_name: 'log_activity'
     }
+    const activity_log_response = 'Activity Log Success Hash'
+    appConductor.once(
+      MockConductor.ZOME_CALL_TYPE,
+      servicelogData,
+      activity_log_response
+    )
+
+    const response = await client.callZomeFunction(
+      'dna_alias',
+      'zome',
+      'zome_fn',
+      {
+        zomeFnArgs: 'String Input'
+      }
+    )
+
+    log.debug('Response: %s', response)
+
+    delete response._metadata
+    expect(response).to.deep.equal({
+      type: 'error',
+      payload: {
+        source: 'HoloError',
+        error: 'HoloError',
+        message:
+          'Error: CONDUCTOR CALL ERROR: {"type":"fake conductor error type","data":"fake conductor error data"}',
+        stack: []
+      }
+    })
   })
-})
 
   function delay(t) {
     return new Promise(function(resolve) {

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -440,7 +440,7 @@ describe("Server with mock Conductor", () => {
     expect(deactivateAppCalled).to.be.true;
   });
 
-it.only('should return a useful error message when a conductor call fails', async () => {
+it('should return a useful error message when a conductor call fails', async () => {
   client = await setup.client({})
 
   const callZomeData = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,18 +72,19 @@
   resolved "https://registry.yarnpkg.com/@holo-host/data-translator/-/data-translator-0.1.1.tgz#aefab77086e2a65d88e77f32b1f6a7f18352fdd9"
   integrity sha512-WIg0RDj+VT2yCJPAWJWJdq5e7mfU2Xm3sSc1s6jyT+DlPzKynZ1QeE282DuwuMWeqhNyyW2haGtADTnom5oKuw==
 
-"@holo-host/mock-conductor@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.3.0.tgz#921dc80def329f19537f69528ae2e899dd64996e"
-  integrity sha512-ZjeRuLsKNiUvGYpsTC3USiNfT77mrl4PGGZAjAAgUC/z3z1gP00FAK+BanvffSRlHYE4zRtqLnhiGy0gLsVJYQ==
+"@holo-host/mock-conductor@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.2.1.tgz#bd9b98e01ea9afac907aa47d04bd9e2374871881"
+  integrity sha512-XRsIkSQ1nTIfeIN5FvjuEGa7wrDKsHFausfupN3vH+MmEYMkng7v0E0QJN1REPfq59XTlMThgSb0HuiH68rnew==
   dependencies:
     "@msgpack/msgpack" "^2.3.0"
     lodash "^4.17.20"
     ws "^7.4.0"
 
-"@holo-host/mock-conductor@git://github.com/Holo-Host/mock-conductor.git#29cd64a2dbdb20d1377983ea7546f3e1e667361d":
-  version "0.2.0"
-  resolved "git://github.com/Holo-Host/mock-conductor.git#29cd64a2dbdb20d1377983ea7546f3e1e667361d"
+"@holo-host/mock-conductor@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.3.0.tgz#921dc80def329f19537f69528ae2e899dd64996e"
+  integrity sha512-ZjeRuLsKNiUvGYpsTC3USiNfT77mrl4PGGZAjAAgUC/z3z1gP00FAK+BanvffSRlHYE4zRtqLnhiGy0gLsVJYQ==
   dependencies:
     "@msgpack/msgpack" "^2.3.0"
     lodash "^4.17.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,14 @@
     lodash "^4.17.20"
     ws "^7.4.0"
 
+"@holo-host/mock-conductor@git://github.com/Holo-Host/mock-conductor.git#29cd64a2dbdb20d1377983ea7546f3e1e667361d":
+  version "0.2.0"
+  resolved "git://github.com/Holo-Host/mock-conductor.git#29cd64a2dbdb20d1377983ea7546f3e1e667361d"
+  dependencies:
+    "@msgpack/msgpack" "^2.3.0"
+    lodash "^4.17.20"
+    ws "^7.4.0"
+
 "@holo-host/wasm-key-manager@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@holo-host/wasm-key-manager/-/wasm-key-manager-1.0.0.tgz#32e5365ddc4518a01c17d2aba09d11bf3a042429"

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,19 +72,19 @@
   resolved "https://registry.yarnpkg.com/@holo-host/data-translator/-/data-translator-0.1.1.tgz#aefab77086e2a65d88e77f32b1f6a7f18352fdd9"
   integrity sha512-WIg0RDj+VT2yCJPAWJWJdq5e7mfU2Xm3sSc1s6jyT+DlPzKynZ1QeE282DuwuMWeqhNyyW2haGtADTnom5oKuw==
 
-"@holo-host/mock-conductor@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.2.1.tgz#bd9b98e01ea9afac907aa47d04bd9e2374871881"
-  integrity sha512-XRsIkSQ1nTIfeIN5FvjuEGa7wrDKsHFausfupN3vH+MmEYMkng7v0E0QJN1REPfq59XTlMThgSb0HuiH68rnew==
+"@holo-host/mock-conductor@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.3.0.tgz#921dc80def329f19537f69528ae2e899dd64996e"
+  integrity sha512-ZjeRuLsKNiUvGYpsTC3USiNfT77mrl4PGGZAjAAgUC/z3z1gP00FAK+BanvffSRlHYE4zRtqLnhiGy0gLsVJYQ==
   dependencies:
     "@msgpack/msgpack" "^2.3.0"
     lodash "^4.17.20"
     ws "^7.4.0"
 
-"@holo-host/mock-conductor@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.3.0.tgz#921dc80def329f19537f69528ae2e899dd64996e"
-  integrity sha512-ZjeRuLsKNiUvGYpsTC3USiNfT77mrl4PGGZAjAAgUC/z3z1gP00FAK+BanvffSRlHYE4zRtqLnhiGy0gLsVJYQ==
+"@holo-host/mock-conductor@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@holo-host/mock-conductor/-/mock-conductor-0.3.1.tgz#8e6397cc2f3eabdd7db869d532b1a3e0ed6d4d31"
+  integrity sha512-IaKKYyYAdPaFLOUINa+aU5CltYgZ7VfvwRmJbXBhPL0rHK6FF9P1y9SggGwTPDEUWZMI1w4RmnEG3wP+FCF6gQ==
   dependencies:
     "@msgpack/msgpack" "^2.3.0"
     lodash "^4.17.20"


### PR DESCRIPTION
Previously whenever a zome call failed, all you saw in chaperone was `CONDUCTOR CALL ERROR: [object Object]`. With this PR, you would actually see the error

Update: I ended up updating the mock conductor dependency in order to write tests for the improved error message, it turns out that the old version of mock conductor we were using was not detecting a lot of things that were wrong with the old tests. I fixed all those problems in this PR as well. Let me know if you want me to split it out into two PRs