### PR TITLE
Retry servicelogger if head moved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1037,14 +1037,28 @@ class Envoy {
     }
 
     log.silly("Recording service confirmation with payload: activity: { request: %s, response: %s, confimation: %s }", client_request, host_response, confirmation);
-    const resp = await this.callConductor("app", {
-      "cell_id": servicelogger_cell_id,
-      "zome_name": "service",
-      "fn_name": "log_activity",
-      payload,
-      cap: null,
-      provenance: buffer_host_agent_servicelogger_id,
-    });
+    let resp
+
+    let retryCall = true
+    while (retryCall) {
+      retryCall = false
+      try {
+        resp = await this.callConductor("app", {
+          "cell_id": servicelogger_cell_id,
+          "zome_name": "service",
+          "fn_name": "log_activity",
+          payload,
+          cap: null,
+          provenance: buffer_host_agent_servicelogger_id,
+        });
+      } catch (e) {
+        if (String(e).includes("source chain head has moved")) {
+          retryCall = true
+        } else {
+          throw e
+        }
+      }
+    }
 
     if (resp) {
       log.silly('\nFinished Servicelogger confirmation: ', resp);

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -561,7 +561,7 @@ describe("Server with mock Conductor", () => {
       servicelogData,
       () => {
         tries += 1
-        return "service logger sucess"
+        return "service logger success"
       },
     )
 

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -440,7 +440,7 @@ describe("Server with mock Conductor", () => {
   it("should handle obscure error from Conductor");
   it("should disconnect Envoy's websocket clients on conductor disconnect");
 
-  it.only("should call ActivateApp and retry if a zome call returns CellMissing", async () => {
+  it("should call ActivateApp and retry if a zome call returns CellMissing", async () => {
     let activateAppCalled = false
     adminConductor.next(({ type, data }) => {
       expect(type).to.equal(MockConductor.ACTIVATE_APP_TYPE)


### PR DESCRIPTION
Currently, when a bunch of zome calls come in at once, only a couple of them succeed and the rest fail with "failed to complete servicelogger confirmation: `Attempted to commit a bundle to the source chain, but the source chain head has moved since the bundle began`"

After this PR, they should all succeed. App developers should also keep in mind this bottleneck and sequentialize their zome calls when possible