### PR TITLE
Update holochain-conductor-api to git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@holo-host/cryptolib": "^0.3.0",
     "@holo-host/data-translator": "^0.1.1",
-    "@holochain/conductor-api": "git://github.com/holochain/holochain-conductor-api.git#d55a5f3a0d772c2f61028b8d0c1b5755944f2286",
+    "@holochain/conductor-api": "git://github.com/holochain/holochain-conductor-api.git#cc743fd6e1f60e148035d54a05949b9ad7b55dec",
     "@holochain/lair-client": "^0.1.1",
     "@msgpack/msgpack": "^2.3.0",
     "@types/ws": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@holo-host/cryptolib": "^0.3.0",
     "@holo-host/data-translator": "^0.1.1",
-    "@holochain/conductor-api": "git://github.com/holochain/holochain-conductor-api.git#a753cee573f55dd220be4fe5c675e3256f0b183c",
+    "@holochain/conductor-api": "git://github.com/holochain/holochain-conductor-api.git#d55a5f3a0d772c2f61028b8d0c1b5755944f2286",
     "@holochain/lair-client": "^0.1.1",
     "@msgpack/msgpack": "^2.3.0",
     "@types/ws": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@holo-host/cryptolib": "^0.3.0",
     "@holo-host/data-translator": "^0.1.1",
-    "@holochain/conductor-api": "^0.0.1-dev.17",
+    "@holochain/conductor-api": "git://github.com/holochain/holochain-conductor-api.git#a753cee573f55dd220be4fe5c675e3256f0b183c",
     "@holochain/lair-client": "^0.1.1",
     "@msgpack/msgpack": "^2.3.0",
     "@types/ws": "^7.4.0",

--- a/src/websocket-wrappers/holochain.ts
+++ b/src/websocket-wrappers/holochain.ts
@@ -6,11 +6,11 @@ const log = require('@whi/stdlog')(path.basename(__filename), {
 import {
   AdminWebsocket,
   AppWebsocket
-} from '@holochain/conductor-api';
+} from '@holochain/conductor-api/src';
 
 import Websocket from 'ws';
 
-import {WsClient as HolochainWsClient} from '@holochain/conductor-api/lib/websocket/client'
+import {WsClient as HolochainWsClient} from '@holochain/conductor-api/src/websocket/client'
 
 import ReconnectingWebSocket from 'reconnecting-websocket';
 

--- a/src/websocket-wrappers/holochain.ts
+++ b/src/websocket-wrappers/holochain.ts
@@ -6,11 +6,11 @@ const log = require('@whi/stdlog')(path.basename(__filename), {
 import {
   AdminWebsocket,
   AppWebsocket
-} from '@holochain/conductor-api/src';
+} from '@holochain/conductor-api';
 
 import Websocket from 'ws';
 
-import {WsClient as HolochainWsClient} from '@holochain/conductor-api/src/websocket/client'
+import {WsClient as HolochainWsClient} from '@holochain/conductor-api/lib/websocket/client'
 
 import ReconnectingWebSocket from 'reconnecting-websocket';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,9 +118,9 @@
     nanoid "^3.1.9"
     ws "^7.3.0"
 
-"@holochain/conductor-api@git://github.com/holochain/holochain-conductor-api.git#a753cee573f55dd220be4fe5c675e3256f0b183c":
+"@holochain/conductor-api@git://github.com/holochain/holochain-conductor-api.git#cc743fd6e1f60e148035d54a05949b9ad7b55dec":
   version "0.0.1-dev.17"
-  resolved "git://github.com/holochain/holochain-conductor-api.git#a753cee573f55dd220be4fe5c675e3256f0b183c"
+  resolved "git://github.com/holochain/holochain-conductor-api.git#cc743fd6e1f60e148035d54a05949b9ad7b55dec"
   dependencies:
     "@msgpack/msgpack" "^2.1.0"
     "@types/ws" "^7.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,10 +118,9 @@
     nanoid "^3.1.9"
     ws "^7.3.0"
 
-"@holochain/conductor-api@^0.0.1-dev.17":
+"@holochain/conductor-api@git://github.com/holochain/holochain-conductor-api.git#a753cee573f55dd220be4fe5c675e3256f0b183c":
   version "0.0.1-dev.17"
-  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.1-dev.17.tgz#ec082b6f5da7d867d3f2c089a5e1ccfac0af0e54"
-  integrity sha512-HuZDN2c8r3JpIHLNoSFv2QeR8d0w8qR0ewNrR4uRR3t9JXBsnMLpW3UiFt++R4tFJNp9GB337HxmK5h7kbxWbA==
+  resolved "git://github.com/holochain/holochain-conductor-api.git#a753cee573f55dd220be4fe5c675e3256f0b183c"
   dependencies:
     "@msgpack/msgpack" "^2.1.0"
     "@types/ws" "^7.2.4"


### PR DESCRIPTION
Fixes the error we're seeing in hosted dev testing:

```
CONDUCTOR CALL ERROR: {"type":"ribosome_err", "data": "invalid type byte array, expected struct ChannelInput"}
```

Based on this PR https://github.com/holochain/holochain-conductor-api/pull/57 except that we can't use holochain-conductor-api develop until we're using a newer holochain version. So it really uses this branch https://github.com/holochain/holochain-conductor-api/compare/old-holochain-fork