### PR TITLE
D-01227: Return proper lair error upon wormhole timeout

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/d5a7ad236255680dc7426b14d20a3a7b9b4d26f3.tar.gz";
-  sha256 = "124jv5v1rblf13ma3fyrxjg85fz502l50gl0jgkn5d0bsnyxwbxa";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/51f3a38e969c3543b1000154507ad7d4f4db8b35.tar.gz";
+  sha256 = "1fvy0asfsnfph2m4hg3kdgqa8gp58agmz0f6zxpc09yw8p9awg59";
 })

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "@holo-host/cryptolib": "^0.3.0",
     "@holo-host/data-translator": "^0.1.1",
-    "@holochain/conductor-api": "^0.0.1",
-    "@holochain/lair-client": "^0.1.1",
+    "@holochain/conductor-api": "^0.0.2",
+    "@holochain/lair-client": "git://github.com/holochain/lair-client-js.git#5db54d5560ad2f64b402744fc460a0a5d231d40f",
     "@msgpack/msgpack": "^2.3.0",
     "@types/ws": "^7.4.0",
     "@whi/stdlog": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@holo-host/cryptolib": "^0.3.0",
     "@holo-host/data-translator": "^0.1.1",
     "@holochain/conductor-api": "^0.0.2",
-    "@holochain/lair-client": "git://github.com/holochain/lair-client-js.git#5db54d5560ad2f64b402744fc460a0a5d231d40f",
+    "@holochain/lair-client": "^0.1.2",
     "@msgpack/msgpack": "^2.3.0",
     "@types/ws": "^7.4.0",
     "@whi/stdlog": "^0.3.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ interface EnvoyConfig {
   port?: number;
   NS?: string;
   hosted_app?: HostedAppConfig;
-  app_port_number?: number;
 }
 
 class HoloError extends Error {
@@ -173,8 +172,6 @@ class Envoy {
       "port": this.opts.port,
       "host": "0.0.0.0", // "localhost",
     });
-
-    await this.connected;
 
     this.ws_server.on("connection", async (socket, request) => {
       // path should contain the HHA ID and Agent ID so we can do some checks and alert the
@@ -314,7 +311,6 @@ class Envoy {
       const buffer_agent_id = Codec.AgentId.decodeToHoloHash(agent_id);
       log.info("Encoded Agent ID (%s) into buffer form: %s", agent_id, buffer_agent_id);
 
-      let failed = false;
       try {
         let adminResponse;
         // - Install App - This admin function creates cells for each dna with associated nick, under the hood.
@@ -346,7 +342,6 @@ class Envoy {
 
           if (adminResponse.type !== "success") {
             log.error("Conductor 'installApp' returned non-success response: %s", adminResponse);
-            failed = true
             throw (new HoloError(`Failed to complete 'installApp' for installed_app_id'${hosted_agent_instance_app_id}'.`)).toJSON();
           }
         } catch (err) {
@@ -360,16 +355,8 @@ class Envoy {
 
         await this.signIn(hha_hash, agent_id);
       } catch (err) {
-        failed = true;
         log.error("Failed during DNA processing for Agent (%s) HHA ID (%s): %s", agent_id, hha_hash, String(err));
-      }
-
-      if (failed === true) {
-        // Should rollback cells that were already created
-        // ^^ check to see if is already being done in RSM.
-        log.error("Failed during sign-up process for Agent (%s) HHA ID (%s): %s", agent_id, hha_hash, failure_response);
-
-        return failure_response;
+        return new HoloError(err).toJSON()
       }
 
       // - return success

--- a/src/shim.js
+++ b/src/shim.js
@@ -49,6 +49,7 @@ async function init (lair_socket, shim_socket, signing_handler) {
             continue
           }
         } catch (e) {
+          log.normal("Wormhole failure: %O", e)
           let response = new structs.ErrorResponse(`Failed to fulfill hosted signing request: ${inspect(e)}`)
           conductor_stream.write(response.toMessage(header.id))
           continue

--- a/src/shim.js
+++ b/src/shim.js
@@ -2,6 +2,7 @@ const path = require('path')
 const log = require('@whi/stdlog')(path.basename(__filename), {
   level: process.env.LOG_LEVEL || 'fatal'
 })
+const { inspect } = require('util')
 
 const net = require('net')
 
@@ -37,7 +38,7 @@ async function init (lair_socket, shim_socket, signing_handler) {
         const request = header.wire_type_class.from(await header.payload())
         const pubkey = request.get(0)
         const message = request.get(1)
-        try{
+        try {
           const signature = await signing_handler(pubkey, message)
 
           if (signature !== null) {
@@ -47,10 +48,9 @@ async function init (lair_socket, shim_socket, signing_handler) {
             conductor_stream.write(response.toMessage(header.id))
             continue
           }
-        } catch(e) {
-           // TODO: need to pass the write struct for error to lair
-          log.normal("The wormhole timeouts and we have nothing to send you ... Sorry holochain!!! Error: %s", e);
-          // conductor_stream.write("Shim Error: Failed to sign")
+        } catch (e) {
+          let response = new structs.ErrorResponse(`Failed to fulfill hosted signing request: ${inspect(e)}`)
+          conductor_stream.write(response.toMessage(header.id))
           continue
         }
       }

--- a/src/shim.js
+++ b/src/shim.js
@@ -50,7 +50,7 @@ async function init (lair_socket, shim_socket, signing_handler) {
           }
         } catch (e) {
           log.normal("Wormhole failure: %O", e)
-          let response = new structs.ErrorResponse(`Failed to fulfill hosted signing request: ${inspect(e)}`)
+          const response = new structs.ErrorResponse(`Failed to fulfill hosted signing request: ${inspect(e)}`)
           conductor_stream.write(response.toMessage(header.id))
           continue
         }

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -28,7 +28,6 @@ const envoy_mode_map = {
 
 const envoyOpts = {
   mode: envoy_mode_map.develop,
-  app_port_number: 0,
   hosted_app: {
     dnas: [{
       nick: 'test-hha',

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,9 +98,10 @@
     nanoid "^3.1.9"
     ws "^7.3.0"
 
-"@holochain/lair-client@git://github.com/holochain/lair-client-js.git#5db54d5560ad2f64b402744fc460a0a5d231d40f":
-  version "0.1.1"
-  resolved "git://github.com/holochain/lair-client-js.git#5db54d5560ad2f64b402744fc460a0a5d231d40f"
+"@holochain/lair-client@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@holochain/lair-client/-/lair-client-0.1.2.tgz#8bd218c873b3dbc7b195b85879a0beefeccef8d5"
+  integrity sha512-qVxfNMd+dlLsN6oNSV+sD/VrAa05P8DkiYxtaIsbAJenvq2yaq8uK4LgaNLAHlSWa3s2JfCD+oJU+yxTjhy45g==
   dependencies:
     "@whi/stdlog" "^0.3.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,25 +87,29 @@
   resolved "https://registry.yarnpkg.com/@holo-host/wasm-key-manager/-/wasm-key-manager-1.0.0.tgz#32e5365ddc4518a01c17d2aba09d11bf3a042429"
   integrity sha512-GTfeQ2iYvYYrIkuaF0QupWP/y8sdItwL6Tr1osyaU7eUsWtGfpZqDcTZny8KNDdnQAEEP2nDWZORA/Z3EMJa3w==
 
-"@holochain/conductor-api@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.1.tgz#a45c32d9d7713232dfab6833d4363b3a20cc157a"
-  integrity sha512-Vng5LG8JN1Zh7/s8OMOQKVih/Cz4zJo/6xpXnOYX148XC8bakKuaRXV08sTUWZMKElbq4BqZFTVcxJw3ouPt+w==
+"@holochain/conductor-api@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@holochain/conductor-api/-/conductor-api-0.0.2.tgz#054c17e0ed03ba8fdbbf358b1e83ec4cafddda95"
+  integrity sha512-kZxtIV99btLnJ2y3WRl6ORNSZkdzSWAA4I9aTsYupDK0a/0q/RNv8UF3YocahIVL2o93cC9QLKxGo7bjLigFWA==
   dependencies:
-    "@msgpack/msgpack" "^2.1.0"
+    "@msgpack/msgpack" "2.4.0"
     "@types/ws" "^7.2.4"
     isomorphic-ws "^4.0.1"
     nanoid "^3.1.9"
     ws "^7.3.0"
 
-"@holochain/lair-client@^0.1.1":
+"@holochain/lair-client@git://github.com/holochain/lair-client-js.git#5db54d5560ad2f64b402744fc460a0a5d231d40f":
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@holochain/lair-client/-/lair-client-0.1.1.tgz#7a9c24df883468c5ce9d43526724589921b8c548"
-  integrity sha512-FDjWvM/+BiSuHYdZiQVY6XD4rS/byNP8lpWcS+1AFsoLaWXJqKGKS8BDdzPebeEaxg8CuycKXgIHZM3dDuSgPA==
+  resolved "git://github.com/holochain/lair-client-js.git#5db54d5560ad2f64b402744fc460a0a5d231d40f"
   dependencies:
     "@whi/stdlog" "^0.3.4"
 
-"@msgpack/msgpack@^2.1.0", "@msgpack/msgpack@^2.3.0":
+"@msgpack/msgpack@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.4.0.tgz#789c69301388a6a44a47ce654014ecd1703c8fcc"
+  integrity sha512-5qzv53J43V8GaYsaETs29Q0Ehw9Dog6SG18MASZRQDuZYXtA5T7pymGE2S40NL0X8sjl8+TybmRa5O8d45V7MQ==
+
+"@msgpack/msgpack@^2.3.0":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.5.1.tgz#758de4db603dd48832029e68f15dd6cf83ddfa80"
   integrity sha512-l44t7u0VxuHZT5D2zCdsRbkUPkrAJMu4wyXTvHr75eXICklf38NZncRqPYA4g9t7rprPuRCPYT5+pTLihuSKRA==


### PR DESCRIPTION
Without this change, wormhole timeouts often cause the lair client built in to holochain to enter an unrecoverable state.

Before we can merge this into develop, a few dependencies need to be updated:
- `lair-client-js`
  1. Merge https://github.com/holochain/lair-client-js/pull/5 and https://github.com/holochain/lair-client-js/pull/6
  2. Release a new version of lair-client-js so that we can depend on it in envoy
- `holochain`:
  1. Release new version of `lair_keystore_api` and `lair_keystore_client` so that we can depend on them in holochain
  2. Create a branch of holochain that uses the new lair releases
  3. Update holo-nixpkgs to use that new branch of holochain: https://github.com/Holo-Host/holo-nixpkgs/pull/773

Tests pass locally using a local checkout of holochain where I updated the lair dependencies to be git based.