### PR TITLE
Activation/deactivation fixes + added logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -261,10 +261,12 @@ class Envoy {
 
 
           app_state.desired_activation_state = 'deactivated'
+          log.normal('setting desired state to deactivated. actual:', this.app_states[installed_app_id].desired_activation_state)
           app_state.desired_activation_state_changed_at = Date.now()
 
 
           let deactivationInterval = setInterval(() => {
+            log.normal("trying to deactivate. observed desired: ", app_state.desired_activation_state)
             if (app_state.desired_activation_state === 'activated') {
               clearInterval(deactivationInterval)
               return
@@ -712,8 +714,11 @@ class Envoy {
     try {
       await new Promise<void>((resolve, reject) => {
         app_state.desired_activation_state = 'activated'
+        log.normal('setting desired state to activated. actual:', this.app_states[installed_app_id].desired_activation_state)
+        app_state.desired_activation_state_changed_at = Date.now()
 
         const tryToActivate = async () => {
+          log.normal("trying to activate. observed desired: ", app_state.desired_activation_state)
           if (app_state.desired_activation_state === 'deactivated') {
             // nobody should ever see this error, because chaperone is disconnected
             reject('App already trying to deactivate')

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ class Envoy {
             // dont deactivate too soon or if currently transitioning
             if (app_state.activation_state_changed_at + 5000 >= Date.now() ||
                 app_state.desired_activation_state_changed_at + 5000 >= Date.now() ||
-                app_state.desired_activation_state.endsWith('ing')
+                app_state.activation_state === "deactivating" || app_state.activation_state === "activating"
             ) {
               return;
             }
@@ -745,7 +745,7 @@ class Envoy {
             return
           }
           // don't try and change state too soon or if already transitioning
-          if (app_state.activation_state_changed_at + 5000 >= Date.now() || app_state.activation_state.endsWith('ing')) return
+          if (app_state.activation_state_changed_at + 5000 >= Date.now() || app_state.activation_state === "activating" || app_state.activation_state === "deactivating") return
 
           try {
             app_state.activation_state = 'activating'

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,16 +268,23 @@ class Envoy {
           app_state.desired_activation_state_changed_at = Date.now()
 
 
+          const when_this_interval = Date.now().toLocaleString()
           let deactivationInterval = setInterval(() => {
-            log.normal("trying to deactivate. observed desired: %s", app_state.desired_activation_state)
+            log.normal("trying to deactivate. desired_activation_state: %s", app_state.desired_activation_state)
+            log.normal("this interval initiated at: %s", when_this_interval)
+            log.normal("app_state: %s", inspect(app_state))
+
             if (app_state.desired_activation_state === 'activated') {
+              log.normal("clearing deactivation interval initiated at: %s because of something in app_state", when_this_interval)
+
               clearInterval(deactivationInterval)
               return
             }
 
+            // dont deactivate too soon or if currently transitioning
             if (app_state.activation_state_changed_at + 5000 >= Date.now() ||
-                app_state.activation_state !== 'activated' ||
-                app_state.desired_activation_state_changed_at + 5000 >= Date.now()
+                app_state.desired_activation_state_changed_at + 5000 >= Date.now() ||
+                app_state.desired_activation_state.endsWith('ing')
             ) {
               return;
             }
@@ -288,9 +295,13 @@ class Envoy {
             .then(() => {
               app_state.activation_state = 'deactivated'
               app_state.activation_state_changed_at = Date.now()
+              log.normal("clearing deactivation interval initiated at: %s because sucessfully deactivated", when_this_interval)
+
               clearInterval(deactivationInterval)
             })
             .catch(err => {
+              log.normal("clearing deactivation interval initiated at: %s because error deactivating", when_this_interval)
+
               clearInterval(deactivationInterval)
               if (err.toString().includes("AppNotActive")) {
                 app_state.activation_state = 'deactivated'
@@ -712,6 +723,7 @@ class Envoy {
     const app_state = this.app_states[installed_app_id]
 
     let activation_interval
+    const when_this_interval = Date.now().toLocaleString()
 
     // let the record show, we're not happy with this code.
     try {
@@ -720,15 +732,20 @@ class Envoy {
         log.normal('setting desired state to activated. actual: %s', this.app_states[installed_app_id].desired_activation_state)
         app_state.desired_activation_state_changed_at = Date.now()
 
+
         const tryToActivate = async () => {
-          log.normal("trying to activate. observed desired: %s", app_state.desired_activation_state)
+          log.normal("trying to activate. desired_activation_state: %s", app_state.desired_activation_state)
+          log.normal("this interval initiated at: %s", when_this_interval)
+          log.normal("app_state: %s", inspect(app_state))
+
+
           if (app_state.desired_activation_state === 'deactivated') {
             // nobody should ever see this error, because chaperone is disconnected
             reject('App already trying to deactivate')
             return
           }
-          // don't try and change state too soon
-          if (app_state.activation_state_changed_at + 5000 >= Date.now() || app_state.activation_state !== 'deactivated') return
+          // don't try and change state too soon or if already transitioning
+          if (app_state.activation_state_changed_at + 5000 >= Date.now() || app_state.activation_state.endsWith('ing')) return
 
           try {
             app_state.activation_state = 'activating'
@@ -750,6 +767,7 @@ class Envoy {
         activation_interval = setInterval(tryToActivate, 5000)
       })
     } finally {
+      log.normal("clearing Activation Interval started at: %s", when_this_interval)
       clearInterval(activation_interval)
     }
     return true

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,12 +261,12 @@ class Envoy {
 
 
           app_state.desired_activation_state = 'deactivated'
-          log.normal('setting desired state to deactivated. actual:', this.app_states[installed_app_id].desired_activation_state)
+          log.normal('setting desired state to deactivated. actual: %s', this.app_states[installed_app_id].desired_activation_state)
           app_state.desired_activation_state_changed_at = Date.now()
 
 
           let deactivationInterval = setInterval(() => {
-            log.normal("trying to deactivate. observed desired: ", app_state.desired_activation_state)
+            log.normal("trying to deactivate. observed desired: %s", app_state.desired_activation_state)
             if (app_state.desired_activation_state === 'activated') {
               clearInterval(deactivationInterval)
               return
@@ -714,11 +714,11 @@ class Envoy {
     try {
       await new Promise<void>((resolve, reject) => {
         app_state.desired_activation_state = 'activated'
-        log.normal('setting desired state to activated. actual:', this.app_states[installed_app_id].desired_activation_state)
+        log.normal('setting desired state to activated. actual: %s', this.app_states[installed_app_id].desired_activation_state)
         app_state.desired_activation_state_changed_at = Date.now()
 
         const tryToActivate = async () => {
-          log.normal("trying to activate. observed desired: ", app_state.desired_activation_state)
+          log.normal("trying to activate. observed desired: %s", app_state.desired_activation_state)
           if (app_state.desired_activation_state === 'deactivated') {
             // nobody should ever see this error, because chaperone is disconnected
             reject('App already trying to deactivate')

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,11 +207,14 @@ class Envoy {
       log.normal("%s (%s) connection for HHA ID: %s", anonymous ? "Anonymous" : "Agent", agent_id, hha_hash);
 
       const installed_app_id = getInstalledAppId(hha_hash, agent_id)
-      this.app_states[installed_app_id] = {
-        activation_state: 'deactivated',
-        activation_state_changed_at: 0,
-        desired_activation_state: 'deactivated',
-        desired_activation_state_changed_at: 0
+      if (!this.app_states[installed_app_id]) {
+        log.normal("initializing app state for installed_app_id %s", installed_app_id)
+        this.app_states[installed_app_id] = {
+          activation_state: 'deactivated',
+          activation_state_changed_at: 0,
+          desired_activation_state: 'deactivated',
+          desired_activation_state_changed_at: 0
+        }
       }
 
       if (anonymous) {

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -449,7 +449,6 @@ describe("Server with mock Conductor", () => {
 
   it("should call deactivate on conductor when client disconnects", async function() {
     this.timeout(20_000)
-    console.log("***********************************************************************************************")
     const agent_id = "uhCAk6n7bFZ2_28kUYCDKmU8-2K9z3BzUH4exiyocxR6N5HvshouY";
     let activateAppCalled = false;
     let deactivateAppCalled = false;

--- a/tests/unit/test_server_mock_conductor.js
+++ b/tests/unit/test_server_mock_conductor.js
@@ -447,7 +447,9 @@ describe("Server with mock Conductor", () => {
   it("should handle obscure error from Conductor");
   it("should disconnect Envoy's websocket clients on conductor disconnect");
 
-  it("should call deactivate on conductor when client disconnects", async () => {
+  it("should call deactivate on conductor when client disconnects", async function() {
+    this.timeout(20_000)
+    console.log("***********************************************************************************************")
     const agent_id = "uhCAk6n7bFZ2_28kUYCDKmU8-2K9z3BzUH4exiyocxR6N5HvshouY";
     let activateAppCalled = false;
     let deactivateAppCalled = false;


### PR DESCRIPTION
This PR solves two bugs:
- App gets left deactivated after a hiccup because on reconnection, app_state was getting clobbered
- Sometimes envoy would repeatedly try to activate/deactivate the same app when it was already in the desired state
Also, with this PR in place, @robbiecarlton and I were unable to reproduce that closing tab during sign up breaks other users on the same host.