### PR TITLE
bump nixpkgs rev to `fb8f355a` from PR #816

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/3de358aa2d1473bd721f4e39228d18c4162096f4.tar.gz";
-  sha256 = "1s15x9yvf6idajyhxhklb6wgmn322n4cy58w2929gw4df8xq4w9s";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/fb8f355ad8bb79e1eb15c2b37f81a041cec58338.tar.gz";
+  sha256 = "1fs1p6x05vgcq3fxwkz1y7hyb2c7321cmrsdqjwbr6jrikvig8mq";
 })


### PR DESCRIPTION
### Updates:
 - aligns nix-env and tests with current holo-nixpkgs testing env:
   - holo-nixpkgs rev: `fb8f355ad8bb79e1eb15c2b37f81a041cec58338`
   - holochain rev: `1050f6b064a44a6d6b845940bf4b83cb92f0472f`